### PR TITLE
Fix compile error from last PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ block-modes = "^0.3"
 crypto-mac = "0.7"
 hmac = "^0.7"
 sha-1 = "^0.8"
+subtle = "2.0"
 
 [features]
 default = ["online"]


### PR DESCRIPTION
Hello, the last PR seems to have some errors, these changes should fix them.

About the new dependency introduced, I checked the source for another one of the crypto libraries in use (`crypto_mac`) to see what would be appropiate:
https://docs.rs/crypto-mac/0.7.0/src/crypto_mac/lib.rs.html#13

If you prefer an alternative, I can change it no problem.

PS: I keep a fork of this project with a feature to disable `usb`, similar to the existing `online` one. Would you be interested in another PR for that? The reason is I'm developing server software and I'd rather not introduce a dependency to `libusb`.