### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ path = "src/lib.rs"
 
 [dependencies]
 url = "1.7"
-reqwest = {version = "0.8", optional = true}
-rand = "0.4"
-base64 = "0.9"
+reqwest = {version = "0.9", optional = true}
+rand = "0.6"
+base64 = "0.10"
 threadpool = "1.7"
 bitflags = "1.0.3"
 libusb = {version = "0.2", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,13 @@ use yubicoerror::YubicoError;
 use libusb::{Context};
 
 #[cfg(feature = "online")]
-use reqwest::header::{Headers, UserAgent};
+use reqwest::header::USER_AGENT;
 
 use std::io::prelude::*;
 use base64::{encode, decode};
-use rand::{OsRng, Rng};
+use rand::Rng;
+use rand::rngs::OsRng;
+use rand::distributions::Alphanumeric;
 use threadpool::ThreadPool;
 use std::collections::BTreeMap;
 use std::sync::mpsc::{ channel, Sender };
@@ -294,7 +296,7 @@ impl Yubico {
 
     fn generate_nonce(&self) -> String {
         OsRng::new().unwrap()
-                    .gen_ascii_chars()
+                    .sample_iter(&Alphanumeric)
                     .take(40)
                     .collect()
     }    
@@ -401,14 +403,10 @@ impl RequestHandler {
     }
 
     pub fn get(&self, url: String) -> Result<String> {
-        let mut custon_headers = Headers::new();
-
-        custon_headers.set(UserAgent::new("github.com/wisespace-io/yubico-rs"));
-
         let client = reqwest::Client::new();
         let mut response = client
             .get(url.as_str())
-            .headers(custon_headers)
+            .header(USER_AGENT, "github.com/wisespace-io/yubico-rs")
             .send()?;
 
         let mut data = String::new();


### PR DESCRIPTION
The `reqwest` version used is incompatible with OpenSSL version 1.1.1a (See https://github.com/dani-garcia/bitwarden_rs/issues/337). The issue is fixed in 0.9.

I also decided to update the other libraries to avoid accumulating breaking changes (both `reqwest` and `rand` needed some changes already), but I can remove those changes if you prefer to keep the old versions.