### PR TITLE
Timeoutv2

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -31,7 +31,7 @@ impl AsyncVerifier {
         }
     }
 
-    pub fn verify<S>(&mut self, otp: S) -> Result<impl Future<Item = (), Error = YubicoError>>
+    pub fn verify<S>(&self, otp: S) -> Result<impl Future<Item = (), Error = YubicoError>>
     where
         S: Into<String>,
     {

--- a/src/async.rs
+++ b/src/async.rs
@@ -15,7 +15,7 @@ pub fn verify_async<S>(
 where
     S: Into<String>,
 {
-    AsyncVerifier::new(config).verify(otp)
+    AsyncVerifier::new(config)?.verify(otp)
 }
 
 pub struct AsyncVerifier {
@@ -24,11 +24,10 @@ pub struct AsyncVerifier {
 }
 
 impl AsyncVerifier {
-    pub fn new(config: Config) -> AsyncVerifier {
-        AsyncVerifier {
-            client: Client::new(),
-            config,
-        }
+    pub fn new(config: Config) -> Result<AsyncVerifier> {
+        let client = Client::builder().timeout(config.request_timeout).build()?;
+
+        Ok(AsyncVerifier { client, config })
     }
 
     pub fn verify<S>(&self, otp: S) -> Result<impl Future<Item = (), Error = YubicoError>>

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::time::Duration;
 
 static API1_HOST: &'static str = "https://api.yubico.com/wsapi/2.0/verify";
 static API2_HOST: &'static str = "https://api2.yubico.com/wsapi/2.0/verify";
@@ -57,6 +58,8 @@ pub struct Config {
     pub api_hosts: Vec<String>,
     pub user_agent: String,
     pub sync_level: SyncLevel,
+    /// The timeout for HTTP requests.
+    pub request_timeout: Duration,
 }
 
 #[allow(dead_code)]
@@ -68,6 +71,7 @@ impl Config {
             api_hosts: build_hosts(),
             user_agent: "github.com/wisespace-io/yubico-rs".to_string(),
             sync_level: SyncLevel::secure(),
+            request_timeout: Duration::from_secs(30), // Value taken from the reqwest crate.
         }
     }
 
@@ -99,6 +103,11 @@ impl Config {
 
     pub fn set_sync_level(mut self, level: SyncLevel) -> Self {
         self.sync_level = level;
+        self
+    }
+
+    pub fn set_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
 use std::fmt::Display;
 use std::time::Duration;
 
-static API1_HOST: &'static str = "https://api.yubico.com/wsapi/2.0/verify";
-static API2_HOST: &'static str = "https://api2.yubico.com/wsapi/2.0/verify";
-static API3_HOST: &'static str = "https://api3.yubico.com/wsapi/2.0/verify";
-static API4_HOST: &'static str = "https://api4.yubico.com/wsapi/2.0/verify";
-static API5_HOST: &'static str = "https://api5.yubico.com/wsapi/2.0/verify";
+static API1_HOST: &str = "https://api.yubico.com/wsapi/2.0/verify";
+static API2_HOST: &str = "https://api2.yubico.com/wsapi/2.0/verify";
+static API3_HOST: &str = "https://api3.yubico.com/wsapi/2.0/verify";
+static API4_HOST: &str = "https://api4.yubico.com/wsapi/2.0/verify";
+static API5_HOST: &str = "https://api5.yubico.com/wsapi/2.0/verify";
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Slot {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -81,8 +81,7 @@ impl Verifier {
         if success {
             Ok("The OTP is valid.".into())
         } else {
-            let result = results.pop().unwrap();
-            result
+            results.pop().ok_or_else(|| YubicoError::InvalidOtp)?
         }
     }
 }

--- a/src/yubicoerror.rs
+++ b/src/yubicoerror.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc::RecvError as channelError;
 
 #[derive(Debug)]
 pub enum YubicoError {
+    ConfigurationError(reqwest::Error),
     Network(reqwest::Error),
     HTTPStatusCode(reqwest::StatusCode),
     IOError(ioError),
@@ -32,6 +33,7 @@ pub enum YubicoError {
 impl fmt::Display for YubicoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            YubicoError::ConfigurationError(ref err) => write!(f, "Configuration error: {}", err),
             YubicoError::Network(ref err) => write!(f, "Connectivity error: {}", err),
             YubicoError::HTTPStatusCode(code) => write!(f, "Error found: {}", code),
             YubicoError::IOError(ref err) => write!(f, "IO error: {}", err),
@@ -84,6 +86,7 @@ impl fmt::Display for YubicoError {
 impl StdError for YubicoError {
     fn description(&self) -> &str {
         match *self {
+            YubicoError::ConfigurationError(ref err) => err.description(),
             YubicoError::Network(ref err) => err.description(),
             YubicoError::HTTPStatusCode(_) => "200 not received",
             YubicoError::IOError(ref err) => err.description(),

--- a/src/yubicoerror.rs
+++ b/src/yubicoerror.rs
@@ -28,6 +28,8 @@ pub enum YubicoError {
     NonceMismatch,
     SignatureMismatch,
     InvalidKeyLength,
+    InvalidResponse,
+    InvalidOtp,
 }
 
 impl fmt::Display for YubicoError {
@@ -79,6 +81,12 @@ impl fmt::Display for YubicoError {
             YubicoError::InvalidKeyLength => {
                 write!(f, "Invalid key length encountered while building signature")
             }
+            YubicoError::InvalidResponse => {
+                write!(f, "Invalid response from the validation server")
+            }
+            YubicoError::InvalidOtp => {
+                write!(f, "Invalid OTP")
+            }
         }
     }
 }
@@ -110,6 +118,8 @@ impl StdError for YubicoError {
             YubicoError::NonceMismatch => "Nonce in the response is the same as the supplied in the request. It may be an attack attempt",
             YubicoError::SignatureMismatch => "Signature in the response is the same as the supplied in the request. It may be an attack attempt",
             YubicoError::InvalidKeyLength => "Invalid key length",
+            YubicoError::InvalidResponse => "Invalid response from the validation server",
+            YubicoError::InvalidOtp => "Invalid OTP",
         }
     }
 


### PR DESCRIPTION
The goal of this PR is to provide support for a configurable timeout for the HTTP requests.

Now this can only be set when building the `reqwest` client so I opted for implementing a reusable `Verifier` struct in the synchronous API, similarly to what the asynchronous API offers.

I also took this as an opportunity to get rid of some warnings coming from Clippy and of a few `unwrap`s. Feel free to tell me to write a separate PR for these.