### PR TITLE
Use the 2018 Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "yubico"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>", "Pierre Larger <pierre.larger@gmail.com>"]
+edition = "2018"
 
 description = "Yubikey client API library"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your Cargo.toml
 
 ```toml
 [dependencies]
-yubico = "0.7"
+yubico = "0.8"
 ```
 
 The following are a list of Cargo features that can be enabled or disabled:
@@ -37,7 +37,7 @@ You can enable or disable them using the example below:
 
   ```toml
   [dependencies.yubico]
-  version = "0.7"
+  version = "0.8"
   # don't include the default features (online)
   default-features = false
   # cherry-pick individual features
@@ -137,3 +137,7 @@ fn read_user_input() -> String {
     buf
 }
 ```
+
+## Changelog
+
+0.8: Rename the `sync` and `async` modules to `sync_verifier` and `async_verifier` to avoid the use of the `async` reserved keyword.

--- a/src/async_verifier.rs
+++ b/src/async_verifier.rs
@@ -1,12 +1,12 @@
 use futures::Future;
 use futures::Stream;
-use reqwest::async::Client;
 use reqwest::header::USER_AGENT;
+use reqwest::r#async::Client;
 
-use config::Config;
+use crate::config::Config;
+use crate::yubicoerror::YubicoError;
+use crate::{build_request, Result};
 use std::sync::Arc;
-use yubicoerror::YubicoError;
-use {build_request, Result};
 
 pub fn verify_async<S>(
     otp: S,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,8 @@
-extern crate base64;
-extern crate crypto_mac;
 #[cfg(feature = "online-tokio")]
-extern crate futures;
-extern crate hmac;
-extern crate rand;
-extern crate reqwest;
-extern crate sha1;
-extern crate subtle;
-
-extern crate threadpool;
-#[macro_use]
-extern crate url;
-extern crate core;
-
-#[cfg(feature = "online-tokio")]
-pub mod async;
+pub mod async_verifier;
 pub mod config;
 mod sec;
-pub mod sync;
+pub mod sync_verifier;
 pub mod yubicoerror;
 
 use std::collections::BTreeMap;
@@ -27,12 +12,12 @@ use config::Config;
 use rand::distributions::Alphanumeric;
 use rand::rngs::OsRng;
 use rand::Rng;
-use url::percent_encoding::{utf8_percent_encode, SIMPLE_ENCODE_SET};
+use url::percent_encoding::{define_encode_set, utf8_percent_encode, SIMPLE_ENCODE_SET};
 use yubicoerror::YubicoError;
 
 #[cfg(feature = "online-tokio")]
-pub use async::verify_async;
-pub use sync::verify;
+pub use async_verifier::verify_async;
+pub use sync_verifier::verify;
 
 type Result<T> = ::std::result::Result<T, YubicoError>;
 

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1,8 +1,8 @@
+use crate::yubicoerror::YubicoError;
 use base64::decode;
 use crypto_mac::{Mac, MacResult};
 use hmac::Hmac;
 use sha1::{Digest, Sha1};
-use yubicoerror::YubicoError;
 
 type HmacSha1 = Hmac<Sha1>;
 

--- a/src/sync_verifier.rs
+++ b/src/sync_verifier.rs
@@ -5,12 +5,12 @@ use reqwest::header::USER_AGENT;
 use threadpool::ThreadPool;
 
 use crate::build_request;
+use crate::config::Config;
+use crate::yubicoerror::YubicoError;
 use crate::Request;
 use crate::Result;
-use config::Config;
 use reqwest::Client;
 use std::sync::Arc;
-use yubicoerror::YubicoError;
 
 pub fn verify<S>(otp: S, config: Config) -> Result<String>
 where

--- a/src/yubicoerror.rs
+++ b/src/yubicoerror.rs
@@ -84,9 +84,7 @@ impl fmt::Display for YubicoError {
             YubicoError::InvalidResponse => {
                 write!(f, "Invalid response from the validation server")
             }
-            YubicoError::InvalidOtp => {
-                write!(f, "Invalid OTP")
-            }
+            YubicoError::InvalidOtp => write!(f, "Invalid OTP"),
         }
     }
 }


### PR DESCRIPTION
Hi!

The 2018 edition will be needed to support future syntax changes like the `async`/`await` syntax.

Speaking about that, I introduced a breaking change: I renamed the `sync` and `async` modules to `sync_verifier` and `async_verifier` to avoid the use of the `async` reserved keyword.

For that reason I took the liberty to update the version to 0.8.0.

I don't especially need a release for that. (I have another PR coming soon)

