### PR TITLE
Upgrade Tokio to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubico"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>", "Pierre Larger <pierre.larger@gmail.com>"]
 edition = "2018"
 
@@ -21,19 +21,19 @@ path = "src/lib.rs"
 [dependencies]
 base64 = "0.10"
 crypto-mac = "0.7"
-futures-preview = { version = "=0.3.0-alpha.19", optional = true }
+futures = { version = "0.3", optional = true }
 hmac = "^0.7"
 rand = "0.6"
-reqwest = { version = "0.10.0-alpha.1", features = ["blocking"] }
+reqwest = { version = "0.10", features = ["blocking"] }
 sha-1 = "0.8"
 subtle = "2.0"
 threadpool = "1.7"
 url = "1.7"
 
 [dev-dependencies]
-tokio = "0.2.0-alpha.6"
-futures-preview = { version = "=0.3.0-alpha.19" }
+tokio = { version = "0.2", features = ["macros"] }
+futures = "0.3"
 
 [features]
 default = ["online-tokio"]
-online-tokio = ["futures-preview"]
+online-tokio = ["futures"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your Cargo.toml
 
 ```toml
 [dependencies]
-yubico = "0.9.0-alpha.1"
+yubico = "0.9"
 ```
 
 The following are a list of Cargo features that can be enabled or disabled:
@@ -37,8 +37,8 @@ You can enable or disable them using the example below:
 
   ```toml
   [dependencies.yubico]
-  version = "0.9.0-alpha.1"
-  # don't include the default features (online)
+  version = "0.9"
+  # don't include the default features (online-tokio)
   default-features = false
   # cherry-pick individual features
   features = []
@@ -140,5 +140,6 @@ fn read_user_input() -> String {
 
 ## Changelog
 
+0.9.0: Moving to `tokio` 0.2 and `reqwest` 0.10
 0.9.0-alpha.1: Moving to `futures` 0.3.0-alpha.19 
 0.8: Rename the `sync` and `async` modules to `sync_verifier` and `async_verifier` to avoid the use of the `async` reserved keyword.


### PR DESCRIPTION
Hi!

Tokio 0.2 was recently released and a lot of crates have been catching up with that. This PR updates Tokio and Reqwest.