### PR TITLE
Release 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubico"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>", "Pierre Larger <pierre.larger@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ fn read_user_input() -> String {
 
 ## Changelog
 
-    - 0.9.2: Dependencies update
+    - 0.10.0: Upgrade to `tokio` 1.1 and `reqwest` 0.11
+    - 0.9.2: (Yanked) Dependencies update
     - 0.9.1: Set HTTP Proxy (Basic-auth is optional)
     - 0.9.0: Moving to `tokio` 0.2 and `reqwest` 0.10
     - 0.9.0-alpha.1: Moving to `futures` 0.3.0-alpha.19 


### PR DESCRIPTION
Hi!

My latest changes introduced a breaking change, the Tokio upgrade, which causes a panic if used in a Tokio 0.2 runtime.

Could we have 0.9.2 yanked and replaced by 0.10.0?