### PR TITLE
Fix minimal example

### DIFF
--- a/examples/otp.rs
+++ b/examples/otp.rs
@@ -1,15 +1,32 @@
 extern crate yubico;
 
+use std::io::stdin;
 use yubico::config::*;
 use yubico::verify;
 
 fn main() {
-    let config = Config::default()
-        .set_client_id("CLIENT_ID")
-        .set_key("API_KEY");
+    println!("Please plug in a yubikey and enter an OTP");
+    let client_id = std::env::var("YK_CLIENT_ID")
+        .expect("Please set a value to the YK_CLIENT_ID environment variable.");
 
-    match verify("OTP", config) {
+    let api_key = std::env::var("YK_API_KEY")
+        .expect("Please set a value to the YK_API_KEY environment variable.");
+
+    let config = Config::default().set_client_id(client_id).set_key(api_key);
+
+    let otp = read_user_input();
+
+    match verify(otp, config) {
         Ok(answer) => println!("{}", answer),
         Err(e) => println!("Error: {}", e),
     }
+}
+
+fn read_user_input() -> String {
+    let mut buf = String::new();
+    stdin()
+        .read_line(&mut buf)
+        .expect("Could not read user input.");
+
+    buf
 }


### PR DESCRIPTION
This PR fixes the minimal "default" example on how to validate an OTP.
I'm contributing this because I ran the 1st, simplest example but it didn't work because of an unknown reason:
```bash
/tmp/tmp.R4rXVYa3vY/yubico-rs master » cargo run --example otp                                                                                                                                                       
   Compiling yubico v0.11.0 (/tmp/tmp.R4rXVYa3vY/yubico-rs)                                                                                                                                                          
    Finished dev [unoptimized + debuginfo] target(s) in 2.84s                                                                                                                                                        
     Running `target/debug/examples/otp`                                                                                                                                                                             
Error: The OTP has invalid format. 
```

The reason turned out to be hard-coded variables in the `otp.rs`.

With this PR, I'm realigning the file to others in the hierarchy.

---------------
The output is now:
```bash
/tmp/tmp.Y7icMn2EZB/yubico-rs fix/minimal-example » cargo run --release --example otp
    Finished release [optimized] target(s) in 0.06s
     Running `target/release/examples/otp`
Please plug in a yubikey and enter an OTP
ccccccXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
The OTP is valid.
```