### PR TITLE
Dockerize OTP validation functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:alpine as base
+RUN apk update \
+    && apk add \
+        git \
+        gcc \
+        g++ \
+        openssl \
+        openssl-dev \
+        pkgconfig
+
+COPY . /src
+
+RUN rustup update 1.64 && rustup default 1.64
+
+RUN cd /src && \
+    RUSTFLAGS="-C target-feature=-crt-static" cargo build --release --example otp
+
+FROM alpine as tool
+
+RUN apk update && \
+    apk add \
+        libgcc \
+        pcsc-lite-dev
+
+COPY --from=base /src/target/release/examples/otp /usr/local/bin
+ENTRYPOINT [ "otp" ]

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For convenience and reproducibility, a Docker image can be generated via the pro
 
 Build:
 ```bash
-/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker build -t yubico-rs .
+$ docker build -t yubico-rs .
 ...
 Successfully built 983cc040c78e                                                                           
 Successfully tagged yubico-rs:latest
@@ -152,7 +152,7 @@ Successfully tagged yubico-rs:latest
 
 Run:
 ```bash
-/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker run --rm -it -e YK_CLIENT_ID=XXXXX -e YK_API_KEY=XXXXXXXXXXXXXX yubico-rs:latest
+$ docker run --rm -it -e YK_CLIENT_ID=XXXXX -e YK_API_KEY=XXXXXXXXXXXXXX yubico-rs:latest
 Please plug in a yubikey and enter an OTP
 ccccccXXXXXXXXXXXXXXXXXXXX
 The OTP is valid.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ fn read_user_input() -> String {
 }
 ```
 
+## Docker
+
+For convenience and reproducibility, a Docker image can be generated via the provided repo's Dockerfile.
+
+Build:
+```bash
+/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker build -t yubico-rs .
+...
+Successfully built 983cc040c78e                                                                           
+Successfully tagged yubico-rs:latest
+```
+
+Run:
+```bash
+/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker run --rm -it -e YK_CLIENT_ID=XXXXX -e YK_API_KEY=XXXXXXXXXXXXXX yubico-rs:latest
+Please plug in a yubikey and enter an OTP
+ccccccXXXXXXXXXXXXXXXXXXXX
+The OTP is valid.
+```
+
 ## Changelog
 
     - 0.10.0: Upgrade to `tokio` 1.1 and `reqwest` 0.11


### PR DESCRIPTION
This PR adds dockerization of the OTP example for reproducibility.
Depends-on: https://github.com/wisespace-io/yubico-rs/pull/25.

Build:
```bash
/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker build -t yubico-rs .
...
Successfully built 983cc040c78e                                                                           
Successfully tagged yubico-rs:latest
```
Run:
```bash
/tmp/tmp.PUlYOqoG3a/yubico-rs add/dockerfile » docker run --rm -it -e YK_CLIENT_ID=XXXXX -e YK_API_KEY=XXXXXXXXXXXXXX yubico-rs:latest
Please plug in a yubikey and enter an OTP
ccccccXXXXXXXXXXXXXXXXXXXX
The OTP is valid.
```